### PR TITLE
add options and use `for` loop for iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ Continuously fetch records from Kinesis Stream and print it. Useful for debuggin
 	Data: {"id":"0d669fb6-045e-4299-946c-5786037ab638","hoge":"fuga"}
 	...
 
+## Usage
+
+```
+Usage of kineis-tail:
+  -f    tailing kinesis stream forever or not (like: tail -f) (default true)
+  -interval duration
+        seconds for waiting next GetRecords request. (default 3s)
+  -iterator-type string
+        iterator type. Choose from TRIM_HORIZON(default), AT_SEQUENCE_NUMBER, or LATEST. (default "TRIM_HORIZON")
+  -limit int
+        limit records length of each GetRecords request. (default 100)
+  -max-item-size int
+        max byte size per item for printing. (default 4096)
+  -region string
+        the AWS region where your Kinesis Stream is. (default "ap-northeast-1")
+  -stream string
+        your stream name (default "your-stream")
+```
+
 ## How does it works:
 
 * At first, describe stream.

--- a/main.go
+++ b/main.go
@@ -15,24 +15,33 @@ var (
 	region       = flag.String("region", "ap-northeast-1", "the AWS region where your Kinesis Stream is.")
 	iteratorType = flag.String("iterator-type", "TRIM_HORIZON", "iterator type. Choose from TRIM_HORIZON(default), AT_SEQUENCE_NUMBER, or LATEST.")
 	maxItemSize  = flag.Int("max-item-size", 4096, "max byte size per item for printing.")
+	forever      = flag.Bool("f", true, "tailing kinesis stream forever or not (like: tail -f)")
+	limit        = flag.Int64("limit", 100, "limit records length of each GetRecords request.")
+	interval     = flag.Duration("interval", time.Second*3, "seconds for waiting next GetRecords request.")
 )
+
+type Client struct {
+	*kinesis.Kinesis
+	maxItemSize int
+	Limit       *int64
+}
 
 func main() {
 	flag.Parse()
 
 	s := session.New(&aws.Config{Region: aws.String(*region)})
-	kc := kinesis.New(s)
+	c := &Client{Kinesis: kinesis.New(s), maxItemSize: *maxItemSize, Limit: limit}
 
 	streamName := aws.String(*stream)
 
-	streams, err := kc.DescribeStream(&kinesis.DescribeStreamInput{StreamName: streamName})
+	streams, err := c.DescribeStream(&kinesis.DescribeStreamInput{StreamName: streamName})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cannot describe stream. please verify your stream is accecible.: %s", err)
 		os.Exit(1)
 	}
 	fmt.Printf("Your Stream information: %v\n", streams)
 
-	iteratorOutput, err := kc.GetShardIterator(&kinesis.GetShardIteratorInput{
+	iteratorOutput, err := c.GetShardIterator(&kinesis.GetShardIteratorInput{
 		// take first shard.
 		ShardId:           streams.StreamDescription.Shards[0].ShardId,
 		ShardIteratorType: aws.String(*iteratorType),
@@ -44,29 +53,38 @@ func main() {
 	}
 	fmt.Printf("%v\n", iteratorOutput)
 
-	if err := iter(kc, iteratorOutput.ShardIterator, *maxItemSize); err != nil {
-		fmt.Fprintf(os.Stderr, "get records failed: %s", err)
-		os.Exit(1)
+	iter := iteratorOutput.ShardIterator
+	for {
+		if iter == nil && *forever == false {
+			fmt.Fprintf(os.Stderr, "all data in this stream is fetched. : %s")
+			os.Exit(0)
+		}
+		iter, err = c.fetch(iter)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "get records failed: %s", err)
+			os.Exit(1)
+		}
+		time.Sleep(*interval)
 	}
 }
 
 // iter fetch records.
-func iter(kc *kinesis.Kinesis, shardIterator *string, maxItemSize int) error {
-	records, err := kc.GetRecords(&kinesis.GetRecordsInput{
+func (c *Client) fetch(shardIterator *string) (nextShardIterator *string, err error) {
+	records, err := c.GetRecords(&kinesis.GetRecordsInput{
 		ShardIterator: shardIterator,
+		Limit:         c.Limit,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, r := range records.Records {
 		fmt.Printf("ApproximateArrivalTimestamp: %v\n", r.ApproximateArrivalTimestamp)
-		if len(r.Data) > maxItemSize {
-			fmt.Printf("Data: %s\n", r.Data[:maxItemSize-1])
+		if len(r.Data) > c.maxItemSize {
+			fmt.Printf("Data: %s\n", r.Data[:c.maxItemSize-1])
 		} else {
 			fmt.Printf("Data: %s\n", r.Data[:])
 		}
 		fmt.Printf("SequenceNumber: %s\n", *r.SequenceNumber)
 	}
-	time.Sleep(time.Second * 3)
-	return iter(kc, records.NextShardIterator, maxItemSize)
+	return records.NextShardIterator, nil
 }


### PR DESCRIPTION
- add `-f` option for forever scaning. It's working like `tail -f` for
  Kinesis Stream.
- add `-limit` option for specifing max records size for each GetRecords requests.
- add `-interval` options for setting scaning interval.

This changes is not breaking compatibility. Default parameter is not
changed.

fixes #1
